### PR TITLE
Cambio de la navegabilidad

### DIFF
--- a/SistemaDireccionGeneral/Vista/ModificarUsuario_DireccionGeneral.xaml.cs
+++ b/SistemaDireccionGeneral/Vista/ModificarUsuario_DireccionGeneral.xaml.cs
@@ -279,8 +279,8 @@ namespace SistemaDireccionGeneral.Vista
 
         private void btnCancelar_Click(object sender, RoutedEventArgs e)
         {
-            MenuAdministrativo_DireccionGeneral ventanaMenuAdministrativo = new MenuAdministrativo_DireccionGeneral();
-            ventanaMenuAdministrativo.Show();
+            ConsultarUsuario_DireccionGeneral ventanaConsultarUsuairo = new ConsultarUsuario_DireccionGeneral();
+            ventanaConsultarUsuairo.Show();
             this.Close();
         }
 


### PR DESCRIPTION
Se cambio la navegabilidad de ModificarUsuario, ya que no dirigía a la ventana que correspondía.