### PR TITLE
Cambio de posicionamiento de labels IniciarSesión_FXML

### DIFF
--- a/SistemaDelegacionesMunicipales/Vista/IniciarSesion.xaml
+++ b/SistemaDelegacionesMunicipales/Vista/IniciarSesion.xaml
@@ -21,8 +21,9 @@
                 <ImageBrush ImageSource="Imagenes/veracruzlogo.png" Stretch="Uniform"/>
             </Border.Background>
         </Border>
-        <Label Content="Username" HorizontalAlignment="Left" Margin="143,132,0,0" VerticalAlignment="Top"/>
-        <Label Content="Contraseña" HorizontalAlignment="Left" Margin="143,194,0,0" VerticalAlignment="Top" Width="109"/>
+        <Label Content="Username" HorizontalAlignment="Left" Margin="135,112,0,0" VerticalAlignment="Top"/>
+        <Label Content="Contraseña" HorizontalAlignment="Left" Margin="135,174,0,0" VerticalAlignment="Top" Width="109"/>
+        <Label Content="Delegación" HorizontalAlignment="Left" Margin="135,228,0,0" VerticalAlignment="Top"/>
         <Rectangle HorizontalAlignment="Left" Height="15" Stroke="Black" VerticalAlignment="Top" Width="392">
             <Rectangle.Fill>
                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">


### PR DESCRIPTION
Se cambio la posición de los labels de la ventana de iniciar sesión, ya que se encontraban mal posicionados y hacia falta un label llamado "Delegación".