### PR TITLE
Navegabilidad entre menu y chat

### DIFF
--- a/SistemaDireccionGeneral/Vista/ChatGeneral.xaml
+++ b/SistemaDireccionGeneral/Vista/ChatGeneral.xaml
@@ -12,10 +12,10 @@
             <ImageBrush ImageSource="Imagenes/FondoBlanco.jpg"/>
         </Grid.Background>
         <Label x:Name="lbNombreCliente" Content="Nombre Usuario: " HorizontalAlignment="Left" Margin="10,36,0,0" VerticalAlignment="Top" FontSize="18"/>
-        <TextBox x:Name="tbContenido" HorizontalAlignment="Left" Height="192" Margin="67,94,0,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="665" AcceptsReturn="True" VerticalScrollBarVisibility="Visible"/>
+        <TextBox x:Name="tbContenido" HorizontalAlignment="Left" Height="192" Margin="67,94,0,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="665" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Visible"/>
         <TextBox x:Name="tbMensaje" HorizontalAlignment="Left" Height="23" Margin="67,335,0,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="569"/>
         <Button x:Name="btnEnviarMsj" Content="Enviar" HorizontalAlignment="Left" Margin="657,335,0,0" VerticalAlignment="Top" Width="76"/>
-        <Button x:Name="btnSalir" Content="Salir" HorizontalAlignment="Left" Margin="657,36,0,0" VerticalAlignment="Top" Width="76"/>
+        <Button x:Name="btnSalir" Content="Salir" HorizontalAlignment="Left" Margin="657,36,0,0" VerticalAlignment="Top" Width="76" Click="btnSalir_Click"/>
     </Grid>
     
 </Window>

--- a/SistemaDireccionGeneral/Vista/ChatGeneral.xaml.cs
+++ b/SistemaDireccionGeneral/Vista/ChatGeneral.xaml.cs
@@ -23,5 +23,12 @@ namespace SistemaDireccionGeneral.Vista
         {
             InitializeComponent();
         }
+
+        private void btnSalir_Click(object sender, RoutedEventArgs e)
+        {
+            MenuAdministrativo_DireccionGeneral ventanaMenuAdministrativo = new MenuAdministrativo_DireccionGeneral();
+            ventanaMenuAdministrativo.Show();
+            this.Close();
+        }
     }
 }

--- a/SistemaDireccionGeneral/Vista/MenuAdministrativo_DireccionGeneral.xaml
+++ b/SistemaDireccionGeneral/Vista/MenuAdministrativo_DireccionGeneral.xaml
@@ -33,7 +33,7 @@
         <Button x:Name="btnConsultarUsuario" Content="Consultar Usuario" Grid.Column="1" HorizontalAlignment="Center" Grid.Row="4" VerticalAlignment="Center" Width="125" Height="50" FontWeight="Bold" Click="btnConsultarUsuario_Click"/>
         <Button x:Name="btnRegistrarDelegacion" Content="Registrar Delegación" Grid.Column="3" HorizontalAlignment="Center" Grid.Row="3" VerticalAlignment="Bottom" Width="124" Height="50" FontWeight="Bold" Margin="10,0,10,5" Click="btnRegistrarDelegacion_Click"/>
         <Button x:Name="btnConsultarDelegacion" Content="Consultar Delegación" Grid.Column="3" HorizontalAlignment="Center" Grid.Row="4" VerticalAlignment="Center" Width="125" Height="50" FontWeight="Bold" Click="btnConsultarDelegacion_Click"/>
-        <Button x:Name="btnChat" Content="Chat" Grid.Column="3" HorizontalAlignment="Center" Grid.Row="6" VerticalAlignment="Center" Width="125" Height="50" FontWeight="Bold"/>
+        <Button x:Name="btnChat" Content="Chat" Grid.Column="3" HorizontalAlignment="Center" Grid.Row="6" VerticalAlignment="Center" Width="125" Height="50" FontWeight="Bold" Click="btnChat_Click"/>
         <Button x:Name="btnCerrarSesion" Content="Cerrar Sesión" Grid.Column="1" HorizontalAlignment="Center" Grid.Row="6" VerticalAlignment="Center" Width="125" Height="50" FontWeight="Bold"/>
         <Image HorizontalAlignment="Center" Grid.Column="0" Grid.Row="0" Grid.RowSpan="2" Height="100" VerticalAlignment="Center" Width="100">
             <Image.Source>

--- a/SistemaDireccionGeneral/Vista/MenuAdministrativo_DireccionGeneral.xaml.cs
+++ b/SistemaDireccionGeneral/Vista/MenuAdministrativo_DireccionGeneral.xaml.cs
@@ -51,5 +51,12 @@ namespace SistemaDireccionGeneral.Vista
             consultarUsuario.Show();
             this.Close();
         }
+
+        private void btnChat_Click(object sender, RoutedEventArgs e)
+        {
+            ChatGeneral ventanaChatGeneral = new ChatGeneral();
+            ventanaChatGeneral.Show();
+            this.Close();
+        }
     }
 }


### PR DESCRIPTION
Se agrego la navegabilidad entre las ventanas del menu administrativo de la dirección general y la ventana del chat general de la dirección general. De igual forma se hizo un pequeño cambio en el textbox del fxml del chat general para que solo fuera de lectura y no se pueda interactuar con este ultimo.