### PR TITLE
Creación proyecto Chat Servidor

### DIFF
--- a/ChatServidor/ChatServidor.csproj
+++ b/ChatServidor/ChatServidor.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/ChatServidor/Program.cs
+++ b/ChatServidor/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ChatServidor
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/SistemaDelegacionesMunicipales/SistemaTransito.sln
+++ b/SistemaDelegacionesMunicipales/SistemaTransito.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BaseDeDatos", "..\BaseDeDat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prueba", "..\Prueba\Prueba\Prueba.csproj", "{DCEE270E-8030-4109-8866-A5BE4B2E56C8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatServidor", "..\ChatServidor\ChatServidor.csproj", "{39A6BB6C-FFD8-46A3-89C2-AEC6C58B9081}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{DCEE270E-8030-4109-8866-A5BE4B2E56C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DCEE270E-8030-4109-8866-A5BE4B2E56C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DCEE270E-8030-4109-8866-A5BE4B2E56C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39A6BB6C-FFD8-46A3-89C2-AEC6C58B9081}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39A6BB6C-FFD8-46A3-89C2-AEC6C58B9081}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39A6BB6C-FFD8-46A3-89C2-AEC6C58B9081}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39A6BB6C-FFD8-46A3-89C2-AEC6C58B9081}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Se creo el proyecto de ChatServidor de tipo programa de consola dentro de la solución, esto con la finalidad de que el chat general funcione adecuadamente para ambos proyectos de sistemas tanto delegaciones municipales como dirección general sirvan como un chat general del sistema.